### PR TITLE
Go 1.13.1

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -19,20 +19,21 @@ ADD fetch.sh /fetch.sh
 ENV FETCH /fetch.sh
 RUN chmod +x $FETCH
 
+# Make sure apt-get is up to date and dependent packages are installed
 RUN \
   apt-get update && \
   apt-get install -y automake autogen build-essential ca-certificates                    \
-  gcc-6-arm-linux-gnueabi g++-6-arm-linux-gnueabi libc6-dev-armel-cross                \
-  gcc-6-arm-linux-gnueabihf g++-6-arm-linux-gnueabihf libc6-dev-armhf-cross            \
-  gcc-6-aarch64-linux-gnu g++-6-aarch64-linux-gnu libc6-dev-arm64-cross                \
-  gcc-6-mips-linux-gnu g++-6-mips-linux-gnu libc6-dev-mips-cross                       \
-  gcc-6-mipsel-linux-gnu g++-6-mipsel-linux-gnu libc6-dev-mipsel-cross                 \
-  gcc-6-mips64-linux-gnuabi64 g++-6-mips64-linux-gnuabi64 libc6-dev-mips64-cross       \
-  gcc-6-mips64el-linux-gnuabi64 g++-6-mips64el-linux-gnuabi64 libc6-dev-mips64el-cross \
-  gcc-6-multilib gcc-7-multilib g++-6-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
-  libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch          \
-  make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man cmake     \
-  --no-install-recommends
+    gcc-6-arm-linux-gnueabi g++-6-arm-linux-gnueabi libc6-dev-armel-cross                \
+    gcc-6-arm-linux-gnueabihf g++-6-arm-linux-gnueabihf libc6-dev-armhf-cross            \
+    gcc-6-aarch64-linux-gnu g++-6-aarch64-linux-gnu libc6-dev-arm64-cross                \
+    gcc-6-mips-linux-gnu g++-6-mips-linux-gnu libc6-dev-mips-cross                       \
+    gcc-6-mipsel-linux-gnu g++-6-mipsel-linux-gnu libc6-dev-mipsel-cross                 \
+    gcc-6-mips64-linux-gnuabi64 g++-6-mips64-linux-gnuabi64 libc6-dev-mips64-cross       \
+    gcc-6-mips64el-linux-gnuabi64 g++-6-mips64el-linux-gnuabi64 libc6-dev-mips64el-cross \
+    gcc-6-multilib gcc-7-multilib g++-6-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
+    libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch          \
+    make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man cmake     \
+    --no-install-recommends
 
 # Fix any stock package issues
 RUN ln -s /usr/include/asm-generic /usr/include/asm
@@ -102,22 +103,22 @@ ENV ANDROID_CHAIN_386   x86-4.9
 RUN \
   $FETCH $ANDROID_NDK_PATH 0600157c4ddf50ec15b8a037cfc474143f718fd0 && \
   unzip `basename $ANDROID_NDK_PATH` \
-  "$ANDROID_NDK/build/*"                                           \
-  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/include/*"       \
-  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi*/*" \
-  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64*/*"   \
-  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/*"   \
-  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/*"      \
-  "$ANDROID_NDK/prebuilt/linux-x86_64/*"                           \
-  "$ANDROID_NDK/platforms/*/arch-arm/*"                            \
-  "$ANDROID_NDK/platforms/*/arch-arm64/*"                          \
-  "$ANDROID_NDK/platforms/*/arch-x86_64/*"                         \
-  "$ANDROID_NDK/platforms/*/arch-x86/*"                            \
-  "$ANDROID_NDK/toolchains/llvm/*"                                 \
-  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM/*"                   \
-  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM64/*"                 \
-  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_386/*"                   \
-  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_AMD64/*" -d /usr/local > /dev/null && \
+    "$ANDROID_NDK/build/*"                                           \
+    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/include/*"       \
+    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi*/*" \
+    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64*/*"   \
+    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/*"   \
+    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/*"      \
+    "$ANDROID_NDK/prebuilt/linux-x86_64/*"                           \
+    "$ANDROID_NDK/platforms/*/arch-arm/*"                            \
+    "$ANDROID_NDK/platforms/*/arch-arm64/*"                          \
+    "$ANDROID_NDK/platforms/*/arch-x86_64/*"                         \
+    "$ANDROID_NDK/platforms/*/arch-x86/*"                            \
+    "$ANDROID_NDK/toolchains/llvm/*"                                 \
+    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM/*"                   \
+    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM64/*"                 \
+    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_386/*"                   \
+    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_AMD64/*" -d /usr/local > /dev/null && \
   rm -f `basename $ANDROID_NDK_PATH`
 
 ENV PATH /usr/$ANDROID_CHAIN_ARM/bin:$PATH
@@ -129,11 +130,11 @@ ENV ANDROID_SDK_PATH https://dl.google.com/android/repository/sdk-tools-linux-43
 ENV ANDROID_HOME /usr/local/android-sdk
 
 RUN \
-  $FETCH $ANDROID_SDK_PATH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9 && \
-  unzip `basename $ANDROID_SDK_PATH` \
-  -d $ANDROID_HOME > /dev/null && \
-  rm -f `basename $ANDROID_SDK_PATH` && \
-  echo "Y" | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-21" "platforms;android-16"
+    $FETCH $ANDROID_SDK_PATH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9 && \
+    unzip `basename $ANDROID_SDK_PATH` \
+        -d $ANDROID_HOME > /dev/null && \
+    rm -f `basename $ANDROID_SDK_PATH` && \
+    echo "Y" | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-21" "platforms;android-16"
 
 # Inject the old Go package downloader and tool-chain bootstrapper
 ADD bootstrap.sh /bootstrap.sh

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -3,40 +3,36 @@
 #
 # Released under the MIT license.
 
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>
 
 # Mark the image as xgo enabled to support xgo-in-xgo
 ENV XGO_IN_XGO 1
 
-
 # Configure the Go environment, since it's not going to change
 ENV PATH   /usr/local/go/bin:$PATH
 ENV GOPATH /go
-
 
 # Inject the remote file fetcher and checksum verifier
 ADD fetch.sh /fetch.sh
 ENV FETCH /fetch.sh
 RUN chmod +x $FETCH
 
-
-# Make sure apt-get is up to date and dependent packages are installed
 RUN \
   apt-get update && \
   apt-get install -y automake autogen build-essential ca-certificates                    \
-    gcc-6-arm-linux-gnueabi g++-6-arm-linux-gnueabi libc6-dev-armel-cross                \
-    gcc-6-arm-linux-gnueabihf g++-6-arm-linux-gnueabihf libc6-dev-armhf-cross            \
-    gcc-6-aarch64-linux-gnu g++-6-aarch64-linux-gnu libc6-dev-arm64-cross                \
-    gcc-6-mips-linux-gnu g++-6-mips-linux-gnu libc6-dev-mips-cross                       \
-    gcc-6-mipsel-linux-gnu g++-6-mipsel-linux-gnu libc6-dev-mipsel-cross                 \
-    gcc-6-mips64-linux-gnuabi64 g++-6-mips64-linux-gnuabi64 libc6-dev-mips64-cross       \
-    gcc-6-mips64el-linux-gnuabi64 g++-6-mips64el-linux-gnuabi64 libc6-dev-mips64el-cross \
-    gcc-6-multilib gcc-7-multilib g++-6-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
-    libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch          \
-    make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man cmake     \
-    --no-install-recommends
+  gcc-6-arm-linux-gnueabi g++-6-arm-linux-gnueabi libc6-dev-armel-cross                \
+  gcc-6-arm-linux-gnueabihf g++-6-arm-linux-gnueabihf libc6-dev-armhf-cross            \
+  gcc-6-aarch64-linux-gnu g++-6-aarch64-linux-gnu libc6-dev-arm64-cross                \
+  gcc-6-mips-linux-gnu g++-6-mips-linux-gnu libc6-dev-mips-cross                       \
+  gcc-6-mipsel-linux-gnu g++-6-mipsel-linux-gnu libc6-dev-mipsel-cross                 \
+  gcc-6-mips64-linux-gnuabi64 g++-6-mips64-linux-gnuabi64 libc6-dev-mips64-cross       \
+  gcc-6-mips64el-linux-gnuabi64 g++-6-mips64el-linux-gnuabi64 libc6-dev-mips64el-cross \
+  gcc-6-multilib gcc-7-multilib g++-6-multilib gcc-mingw-w64 g++-mingw-w64 clang llvm-dev \
+  libtool libxml2-dev uuid-dev libssl-dev swig openjdk-8-jdk pkg-config patch          \
+  make xz-utils cpio wget zip unzip p7zip git mercurial bzr texinfo help2man cmake     \
+  --no-install-recommends
 
 # Fix any stock package issues
 RUN ln -s /usr/include/asm-generic /usr/include/asm
@@ -68,6 +64,8 @@ RUN  \
   rm -rf /osxcross
 
 ENV PATH $OSX_NDK_X86/bin:$PATH
+ENV LD_LIBRARY_PATH=$OSX_NDK_X86/lib/:$LD_LIBRARY_PATH
+
 
 # Configure the container for iOS cross compilation
 ENV IOS_NDK_ARM_7     /usr/local/ios-ndk-arm-7
@@ -104,22 +102,22 @@ ENV ANDROID_CHAIN_386   x86-4.9
 RUN \
   $FETCH $ANDROID_NDK_PATH 0600157c4ddf50ec15b8a037cfc474143f718fd0 && \
   unzip `basename $ANDROID_NDK_PATH` \
-    "$ANDROID_NDK/build/*"                                           \
-    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/include/*"       \
-    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi*/*" \
-    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64*/*"   \
-    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/*"   \
-    "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/*"      \
-    "$ANDROID_NDK/prebuilt/linux-x86_64/*"                           \
-    "$ANDROID_NDK/platforms/*/arch-arm/*"                            \
-    "$ANDROID_NDK/platforms/*/arch-arm64/*"                          \
-    "$ANDROID_NDK/platforms/*/arch-x86_64/*"                         \
-    "$ANDROID_NDK/platforms/*/arch-x86/*"                            \
-    "$ANDROID_NDK/toolchains/llvm/*"                                 \
-    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM/*"                   \
-    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM64/*"                 \
-    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_386/*"                   \
-    "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_AMD64/*" -d /usr/local > /dev/null && \
+  "$ANDROID_NDK/build/*"                                           \
+  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/include/*"       \
+  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi*/*" \
+  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64*/*"   \
+  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/*"   \
+  "$ANDROID_NDK/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/*"      \
+  "$ANDROID_NDK/prebuilt/linux-x86_64/*"                           \
+  "$ANDROID_NDK/platforms/*/arch-arm/*"                            \
+  "$ANDROID_NDK/platforms/*/arch-arm64/*"                          \
+  "$ANDROID_NDK/platforms/*/arch-x86_64/*"                         \
+  "$ANDROID_NDK/platforms/*/arch-x86/*"                            \
+  "$ANDROID_NDK/toolchains/llvm/*"                                 \
+  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM/*"                   \
+  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_ARM64/*"                 \
+  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_386/*"                   \
+  "$ANDROID_NDK/toolchains/$ANDROID_CHAIN_AMD64/*" -d /usr/local > /dev/null && \
   rm -f `basename $ANDROID_NDK_PATH`
 
 ENV PATH /usr/$ANDROID_CHAIN_ARM/bin:$PATH
@@ -131,11 +129,11 @@ ENV ANDROID_SDK_PATH https://dl.google.com/android/repository/sdk-tools-linux-43
 ENV ANDROID_HOME /usr/local/android-sdk
 
 RUN \
-    $FETCH $ANDROID_SDK_PATH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9 && \
-    unzip `basename $ANDROID_SDK_PATH` \
-        -d $ANDROID_HOME > /dev/null && \
-    rm -f `basename $ANDROID_SDK_PATH` && \
-    echo "Y" | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-21" "platforms;android-16"
+  $FETCH $ANDROID_SDK_PATH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9 && \
+  unzip `basename $ANDROID_SDK_PATH` \
+  -d $ANDROID_HOME > /dev/null && \
+  rm -f `basename $ANDROID_SDK_PATH` && \
+  echo "Y" | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-21" "platforms;android-16"
 
 # Inject the old Go package downloader and tool-chain bootstrapper
 ADD bootstrap.sh /bootstrap.sh

--- a/docker/base/bootstrap_pure.sh
+++ b/docker/base/bootstrap_pure.sh
@@ -69,5 +69,10 @@ ln -s /go/bin/xgo /usr/bin/xgo
 # Install gomobile tool for android/ios frameworks
 echo "Installing gomobile..."
 go get -u golang.org/x/mobile/cmd/gomobile
-/go/bin/gomobile init -ndk /usr/local/android-ndk-r13b/
-/go/bin/gomobile version
+cd /go/src/golang.org/x/mobile
+git checkout a27dd33d354d004b2de14a791df5af8a00f68b8e
+go build ./cmd/gobind && mv ./gobind /usr/bin/
+go build ./cmd/gomobile && mv ./gomobile /usr/bin/
+
+/usr/bin/gomobile init -ndk /usr/local/android-ndk-r13b/
+/usr/bin/gomobile version

--- a/docker/go-1.13.1/Dockerfile
+++ b/docker/go-1.13.1/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.11
+# Go cross compiler (xgo): Go 1.13
 # Copyright (c) 2018 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.

--- a/docker/go-1.13.1/Dockerfile
+++ b/docker/go-1.13.1/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.11
+# Copyright (c) 2018 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM mysteriumnetwork/xgo:base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+ENV CGO_LDFLAGS_ALLOW -fobjc-arc
+ENV GO_VERSION 1131
+
+RUN \
+  export ROOT_DIST=https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz && \
+  export ROOT_DIST_SHA=94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124 && \
+  \
+  $BOOTSTRAP_PURE


### PR DESCRIPTION
- Updated base image to use ubuntu:18.04
- Added go 1.13.1
- Fixed gomobile version commit since it is no longer compatible with our node packaging for android and ios